### PR TITLE
Adding new feature to support test databases to store test results.

### DIFF
--- a/golem/core/report.py
+++ b/golem/core/report.py
@@ -2,6 +2,8 @@
 import json
 import os
 import uuid
+import getpass
+import socket
 
 
 def create_execution_directory(workspace, project, timestamp,
@@ -61,7 +63,7 @@ def create_report_directory(execution_directory, test_case_name, is_suite):
     return report_directory
 
 
-def generate_report(report_directory, test_case_name, test_data, result):
+def generate_report(report_directory, test_case_name, test_data, result, timestamp, id):
     """Generate the json report for a single test execution."""
     json_report_path = os.path.join(report_directory, 'report.json')
 
@@ -111,8 +113,13 @@ def generate_report(report_directory, test_case_name, test_data, result):
         'browser': output_browser,
         'test_data': serializable_data,
         'environment': env_name,
-        'set_name': result['set_name']
+        'set_name': result['set_name'],
+        'suite_timestamp': timestamp,
+        'test_id': id,
+        'user': getpass.getuser(),
+        'hostname': socket.gethostname()
     }
 
     with open(json_report_path, 'w', encoding='utf-8') as json_file:
         json.dump(report, json_file, indent=4)
+    return report

--- a/golem/core/settings_manager.py
+++ b/golem/core/settings_manager.py
@@ -53,7 +53,22 @@ SETTINGS_FILE_CONTENT = (
 "console_log_level": "INFO",
 
 // Log all events, instead of just Golem events. Default is true
-"log_all_events": true
+"log_all_events": true,
+
+// Stores test results when enabled. Options are: true, false
+// Default option is false
+"results_to_db": false,
+
+// Test DB related configurations
+// Test DB type. Option are MONGO, TINYDB
+// Default is TINYDB
+"db_type": "TINYDB",
+
+// Test DB host. Default is EMPTY
+"db_string": "",
+
+// Test DB name, Default is testdb
+"db_name": "testdb"
 }
 """)
 
@@ -81,7 +96,11 @@ DEFAULTS = [
     ('remote_url', None),
     ('remote_browsers', {}),
     ('console_log_level', 'INFO'),
-    ('log_all_events', True)
+    ('log_all_events', True),
+    ('results_to_db', False),
+    ('db_string', ''),
+    ('db_type', 'TINYDB'),
+    ('db_name', 'testdb')
 ]
 
 

--- a/golem/core/test_execution.py
+++ b/golem/core/test_execution.py
@@ -19,3 +19,4 @@ interactive = False
 
 test_data = None
 
+db = None

--- a/golem/core/utils.py
+++ b/golem/core/utils.py
@@ -371,3 +371,13 @@ def match_latest_executable_path(glob_path):
         return highest_version[0][0]
     else:
         return None
+
+def get_db_connection(settings):
+    if settings["db_type"] == "MONGO":
+        from golem.db import Mongo
+        return Mongo(**settings).db
+    elif settings["db_type"] == "TINYDB":
+        from golem.db import Tinydb
+        return Tinydb(**settings).db
+    else:
+        return None

--- a/golem/db.py
+++ b/golem/db.py
@@ -1,0 +1,28 @@
+import pymongo
+import tinymongo
+
+
+class Mongo(object):
+    """
+    Creating Connection object for Mongo DB.
+    """
+
+    db = None
+
+    def __init__(self, **kwargs):
+        db_string = kwargs["db_string"]
+        db_name = kwargs["db_name"]
+        connection = pymongo.MongoClient(db_string)
+        self.db = connection[db_name]
+
+class Tinydb(object):
+    """
+    Creating Connection object for Tiny DB.
+    """
+
+    db = None
+
+    def __init__(self, **kwargs):
+        db_name = kwargs["db_name"]
+        connection = tinymongo.TinyMongoClient()
+        self.db = connection[db_name]

--- a/golem/execution.py
+++ b/golem/execution.py
@@ -19,6 +19,7 @@ class Execution:
         self.workspace = None
         self.report_directory = None
         self.logger = None
+        self.db = None
 
     def reset(self):
         self.__init__()

--- a/golem/test_runner/multiprocess_executor.py
+++ b/golem/test_runner/multiprocess_executor.py
@@ -4,7 +4,7 @@ provided in parallel using multiprocessing.
 from multiprocessing import Pool
 from multiprocessing.pool import ApplyResult
 
-from golem.core import test_execution
+from golem.core import test_execution, utils
 from golem.test_runner.test_runner import run_test
 
 
@@ -32,7 +32,9 @@ def multiprocess_executor(execution_list, threads=1):
                 test['data_set'],
                 test['driver'],
                 test_execution.settings,
-                test['report_directory'])
+                test['report_directory'],
+                test_execution.timestamp,
+                hash(test_execution.timestamp + utils.get_timestamp() + str(test['data_set'])))
         apply_async = pool.apply_async(run_test, args=args)
         results.append(apply_async)
     map(ApplyResult.wait, results)

--- a/golem/test_runner/start_execution.py
+++ b/golem/test_runner/start_execution.py
@@ -222,6 +222,11 @@ def run_test_or_suite(workspace, project, test=None, suite=None, directory=None)
     if not test_execution.timestamp:
         test_execution.timestamp = utils.get_timestamp()
 
+    # Creates a connection with the test DB.
+    # This test db will be used to store the test results and later it can also be used for storing test run time artifacts.
+    if not test_execution.db:
+        test_execution.db = utils.get_db_connection(test_execution.settings)
+
     # Select which envs to use
     # The user can define environments in the environments.json file.
     # The suite/test can be executed in one or more of these environments.
@@ -291,7 +296,9 @@ def run_test_or_suite(workspace, project, test=None, suite=None, directory=None)
                 run_test(workspace, project,
                          test['test_name'], test['data_set'],
                          test['driver'], test_execution.settings,
-                         test['report_directory'])
+                         test['report_directory'],
+                         test_execution.timestamp,
+                         hash(test_execution.timestamp + utils.get_timestamp() + str(test['data_set'])))
         else:
             # run tests using multiprocessing
             multiprocess_executor(execution_list, execution['workers'])

--- a/golem/test_runner/test_runner.py
+++ b/golem/test_runner/test_runner.py
@@ -20,7 +20,7 @@ class Data(dict):
 
 
 def run_test(workspace, project, test_name, test_data, browser,
-             settings, report_directory):
+             settings, report_directory, timestamp, hash_id):
     """Runs a single test"""
     result = {
         'result': 'pass',
@@ -82,6 +82,7 @@ def run_test(workspace, project, test_name, test_data, browser,
     execution.browser_definition = browser
     execution.settings = settings
     execution.report_directory = report_directory
+    execution.db = utils.get_db_connection(settings)
 
     # add the 'project' directory to python path
     # so it's possible to make relative imports from the test
@@ -175,8 +176,10 @@ def run_test(workspace, project, test_name, test_data, browser,
     result['browser'] = execution.browser_definition['name']
     result['browser_full_name'] = execution.browser_definition['full_name']
     
-    report.generate_report(report_directory, test_name, execution.data, result)
-    
+    test_report = report.generate_report(report_directory, test_name, execution.data, result, timestamp, hash_id)
+    if settings['results_to_db']:
+        execution.db.test_results.insert_one(test_report)
+
     execution.reset()
     execution_logger.reset_logger(logger)
     return

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ selenium
 pytest
 requests
 py-webdriver-manager
+pymongo
+tinymongo

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,6 +4,8 @@ selenium
 pytest
 requests
 py-webdriver-manager
+pymongo
+tinymongo
 sphinx
 recommonmark
 tox

--- a/tests/core/report_test.py
+++ b/tests/core/report_test.py
@@ -1,5 +1,7 @@
 import os
 import json
+import getpass
+import socket
 
 from golem.core import report, utils
 from golem.test_runner import test_runner
@@ -111,7 +113,7 @@ class Test_generate_report:
             'browser_full_name': '',
             'set_name': 'set_001',
         }
-        report.generate_report(report_dir, test_name, test_data, result)
+        report.generate_report(report_dir, test_name, test_data, result, timestamp, hash(timestamp + str(test_data)))
         expected = {
             'test_case': test_name,
             'result': 'pass',
@@ -124,6 +126,10 @@ class Test_generate_report:
             'browser': 'chrome',
             'environment': '',
             'set_name': 'set_001',
+            'suite_timestamp': timestamp,
+            'test_id': hash(timestamp + str(test_data)),
+            'user': getpass.getuser(),
+            'hostname': socket.gethostname(),
             'test_data': {
                 'var1': "'value1'",
                 'var2': "'value2'"
@@ -164,7 +170,7 @@ class Test_generate_report:
             'browser_full_name': '',
             'set_name': 'set_001',
         }
-        report.generate_report(report_dir, test_name, test_data, result)
+        report.generate_report(report_dir, test_name, test_data, result, timestamp, hash(timestamp + str(test_data)))
         expected_a = {
             'test_case': test_name,
             'result': 'pass',
@@ -177,6 +183,10 @@ class Test_generate_report:
             'browser': 'chrome',
             'environment': 'env01',
             'set_name': 'set_001',
+            'suite_timestamp': timestamp,
+            'test_id': hash(timestamp + str(test_data)),
+            'user': getpass.getuser(),
+            'hostname': socket.gethostname(),
             'test_data': {
                 'env': "{'name': 'env01', 'url': '1.1.1.1'}",
                 'var2': "'value2'"

--- a/tests/core/report_test.py
+++ b/tests/core/report_test.py
@@ -204,6 +204,10 @@ class Test_generate_report:
             'browser': 'chrome',
             'environment': 'env01',
             'set_name': 'set_001',
+            'suite_timestamp': timestamp,
+            'test_id': hash(timestamp + str(test_data)),
+            'user': getpass.getuser(),
+            'hostname': socket.gethostname(),
             'test_data': {
                 'env': "{'url': '1.1.1.1', 'name': 'env01'}",
                 'var2': "'value2'"

--- a/tests/core/settings_manager_test.py
+++ b/tests/core/settings_manager_test.py
@@ -71,7 +71,11 @@ class Test_assign_settings_default_values:
             ('remote_url', None),
             ('remote_browsers', {}),
             ('console_log_level', 'INFO'),
-            ('log_all_events', True)
+            ('log_all_events', True),
+            ('results_to_db', False),
+            ('db_string', ''),
+            ('db_type', 'TINYDB'),
+            ('db_name', 'testdb')
         ]
         actual_defaults = settings_manager.DEFAULTS
         assert actual_defaults == expected_defaults
@@ -96,7 +100,11 @@ class Test_assign_settings_default_values:
             'remote_url': None,
             'remote_browsers': {},
             'console_log_level': 'INFO',
-            'log_all_events': True
+            'log_all_events': True,
+            'results_to_db': False,
+            'db_string': '',
+            'db_type': 'TINYDB',
+            'db_name': 'testdb'
         }
         assert normalized == expected
 
@@ -120,7 +128,11 @@ class Test_assign_settings_default_values:
             'remote_url': None,
             'remote_browsers': None,
             'console_log_level': None,
-            'log_all_events': None
+            'log_all_events': None,
+            'results_to_db': None,
+            'db_string': None,
+            'db_type': None,
+            'db_name': None
         }
         normalized = settings_manager.assign_settings_default_values(input_settings)
         expected = {
@@ -140,7 +152,11 @@ class Test_assign_settings_default_values:
             'remote_url': None,
             'remote_browsers': {},
             'console_log_level': 'INFO',
-            'log_all_events': True
+            'log_all_events': True,
+            'results_to_db': False,
+            'db_string': '',
+            'db_type': 'TINYDB',
+            'db_name': 'testdb'
         }
         assert normalized == expected
 
@@ -164,7 +180,11 @@ class Test_assign_settings_default_values:
             'remote_url': '',
             'remote_browsers': '',
             'console_log_level': '',
-            'log_all_events': ''
+            'log_all_events': '',
+            'results_to_db': '',
+            'db_string': '',
+            'db_type': '',
+            'db_name': ''
         }
         normalized = settings_manager.assign_settings_default_values(input_settings)
         expected = {
@@ -184,7 +204,11 @@ class Test_assign_settings_default_values:
             'screenshot_on_error': True,
             'screenshot_on_step': False,
             'test_data': 'csv',
-            'wait_hook': None
+            'wait_hook': None,
+            'results_to_db': False,
+            'db_string': '',
+            'db_type': 'TINYDB',
+            'db_name': 'testdb'
         }
         assert normalized == expected
 
@@ -212,7 +236,11 @@ class Test_get_global_settings:
             'screenshot_on_error': True,
             'screenshot_on_step': False,
             'test_data': 'csv',
-            'wait_hook': None
+            'wait_hook': None,
+            'results_to_db': False,
+            'db_string': '',
+            'db_type': 'TINYDB',
+            'db_name': 'testdb'
         }
         assert global_settings == expected
 
@@ -250,7 +278,11 @@ class Test_get_project_settings:
             'screenshot_on_error': True,
             'screenshot_on_step': False,
             'test_data': 'csv',
-            'wait_hook': None
+            'wait_hook': None,
+            'results_to_db': False,
+            'db_string': '',
+            'db_type': 'TINYDB',
+            'db_name': 'testdb'
         }
         assert project_settings == expected
 


### PR DESCRIPTION
- Adding new functionality to store test results to the database. (depends on the **_results_to_db_** config in **_settings.json_** file)
- Current support is provided for **_MONGO DB_** and **_TINY DB_**.
- in future, this will be extended to support adding runtime test data to the database.