### PR TITLE
Add testbase workflow

### DIFF
--- a/golem/core/file_manager.py
+++ b/golem/core/file_manager.py
@@ -12,7 +12,7 @@ def _directory_element(elem_type, name, dot_path=None):
     return element
 
 
-def generate_file_structure_dict(full_path, original_path=None):
+def generate_file_structure_dict(full_path, original_path=None, exclude_name=""):
     """Generates a dictionary with the preserved structure of a given
     directory.
     Files are stored in tuples, with the first element being the name
@@ -53,13 +53,13 @@ def generate_file_structure_dict(full_path, original_path=None):
             if elem not in ['__pycache__']:
                 directories.append(elem)
         else:
-            cond1 = elem not in ['__init__.py', '.DS_Store']
+            cond1 = elem not in ['__init__.py', '.DS_Store', exclude_name]
             cond2 = not elem.endswith('.csv')
             if cond1 and cond2:
                 files.append(os.path.splitext(elem)[0])
     for directory in directories:
         sub_element = generate_file_structure_dict(os.path.join(full_path, directory),
-                                                   original_path)
+                                                   original_path, exclude_name)
         element['sub_elements'].append(sub_element)
     for filename in files:
         full_file_path = os.path.join(full_path, filename)

--- a/golem/core/file_manager.py
+++ b/golem/core/file_manager.py
@@ -12,7 +12,7 @@ def _directory_element(elem_type, name, dot_path=None):
     return element
 
 
-def generate_file_structure_dict(full_path, original_path=None, exclude_name=""):
+def generate_file_structure_dict(full_path, original_path=None):
     """Generates a dictionary with the preserved structure of a given
     directory.
     Files are stored in tuples, with the first element being the name
@@ -53,13 +53,13 @@ def generate_file_structure_dict(full_path, original_path=None, exclude_name="")
             if elem not in ['__pycache__']:
                 directories.append(elem)
         else:
-            cond1 = elem not in ['__init__.py', '.DS_Store', exclude_name]
+            cond1 = elem not in ['__init__.py', '.DS_Store']
             cond2 = not elem.endswith('.csv')
             if cond1 and cond2:
                 files.append(os.path.splitext(elem)[0])
     for directory in directories:
         sub_element = generate_file_structure_dict(os.path.join(full_path, directory),
-                                                   original_path, exclude_name)
+                                                   original_path)
         element['sub_elements'].append(sub_element)
     for filename in files:
         full_file_path = os.path.join(full_path, filename)

--- a/golem/core/settings_manager.py
+++ b/golem/core/settings_manager.py
@@ -5,10 +5,6 @@ import traceback
 
 SETTINGS_FILE_CONTENT = (
 """{
-
-// Base testcase name, this will be automated created if not null
-"base_name": "base",
-
 // Default timeout in seconds to wait until an element is present
 "search_timeout": 20,
 
@@ -68,7 +64,6 @@ REDUCED_SETTINGS_FILE_CONTENT = (
 """)
 
 DEFAULTS = [
-    ('base_name', None),
     ('search_timeout', 0),
     ('wait_displayed', False),
     ('screenshot_on_error', True),
@@ -92,7 +87,6 @@ DEFAULTS = [
 
 def create_global_settings_file(testdir):
     """Create a new global settings file"""
-    print("Create global settings file")
     settings_path = os.path.join(testdir, 'settings.json')
     with open(settings_path, 'a') as settings_file:
         settings_file.write(SETTINGS_FILE_CONTENT)

--- a/golem/core/settings_manager.py
+++ b/golem/core/settings_manager.py
@@ -7,7 +7,7 @@ SETTINGS_FILE_CONTENT = (
 """{
 
 // Base testcase name, this will be automated created if not null
-"base_name": "base",
+"base_name": "_base",
 
 // Default timeout in seconds to wait until an element is present
 "search_timeout": 20,

--- a/golem/core/settings_manager.py
+++ b/golem/core/settings_manager.py
@@ -6,7 +6,8 @@ import traceback
 SETTINGS_FILE_CONTENT = (
 """{
 
-// Base testcase name, this will be automated created if not null
+// Base testcase name, do not change it in a working project unless
+// you know what you're doing
 "base_name": "_base",
 
 // Default timeout in seconds to wait until an element is present

--- a/golem/core/settings_manager.py
+++ b/golem/core/settings_manager.py
@@ -5,6 +5,10 @@ import traceback
 
 SETTINGS_FILE_CONTENT = (
 """{
+
+// Base testcase name, this will be automated created if not null
+"base_name": "base",
+
 // Default timeout in seconds to wait until an element is present
 "search_timeout": 20,
 
@@ -64,6 +68,7 @@ REDUCED_SETTINGS_FILE_CONTENT = (
 """)
 
 DEFAULTS = [
+    ('base_name', None),
     ('search_timeout', 0),
     ('wait_displayed', False),
     ('screenshot_on_error', True),
@@ -87,6 +92,7 @@ DEFAULTS = [
 
 def create_global_settings_file(testdir):
     """Create a new global settings file"""
+    print("Create global settings file")
     settings_path = os.path.join(testdir, 'settings.json')
     with open(settings_path, 'a') as settings_file:
         settings_file.write(SETTINGS_FILE_CONTENT)

--- a/golem/core/suite.py
+++ b/golem/core/suite.py
@@ -4,7 +4,7 @@ Suites are modules located inside the /suites/ directory
 import os
 import importlib
 
-from golem.core import utils, file_manager
+from golem.core import utils, file_manager, settings_manager
 
 
 def _format_list_items(list_items):
@@ -101,6 +101,10 @@ def get_suite_test_cases(workspace, project, suite):
                 tests = tests + this_dir_tests
             else:
                 tests.append(test)
+    base_name = settings_manager.get_project_settings(workspace, project)['base_name']
+    for test in tests:
+        if test.split(".")[-1] == base_name:
+            tests.remove(test)
     return tests
 
 

--- a/golem/core/suite.py
+++ b/golem/core/suite.py
@@ -4,7 +4,7 @@ Suites are modules located inside the /suites/ directory
 import os
 import importlib
 
-from golem.core import utils, file_manager, settings_manager
+from golem.core import utils, file_manager
 
 
 def _format_list_items(list_items):
@@ -101,10 +101,6 @@ def get_suite_test_cases(workspace, project, suite):
                 tests = tests + this_dir_tests
             else:
                 tests.append(test)
-    base_name = settings_manager.get_project_settings(workspace, project)['base_name']
-    for test in tests:
-        if test.split(".")[-1] == base_name:
-            tests.remove(test)
     return tests
 
 

--- a/golem/core/test_case.py
+++ b/golem/core/test_case.py
@@ -199,8 +199,7 @@ def new_base_test_case(root_path, project, parents, test_base):
 
     """Create a Test Base page."""
     test_case_content = (
-        "\n"
-        "pages = []\n\n"
+        "\n\n"
         "def setup(data):\n"
         "    pass\n\n"
         "def teardown(data):\n"

--- a/golem/core/test_case.py
+++ b/golem/core/test_case.py
@@ -7,9 +7,9 @@ import inspect
 
 from golem.core import (utils,
                         test_execution,
-                        file_manager,
-                        settings_manager)
+                        file_manager)
 from golem.core import test_data as test_data_module
+
 
 def _parse_step(step):
     """Parse a step string of a test function (setup, test or teardown)."""
@@ -159,28 +159,23 @@ def get_test_case_code(path):
 
 
 def new_test_case(root_path, project, parents, tc_name):
-    test_base = settings_manager.get_project_settings(root_path, project)['base_name']
     """Create a new empty test case."""
     test_case_content = (
         "\n"
         "description = ''\n\n"
         "pages = []\n\n"
         "def setup(data):\n"
-        "    {}.setup(data)\n\n"
+        "    pass\n\n"
         "def test(data):\n"
         "    pass\n\n"
         "def teardown(data):\n"
-        "    {}.setup(data)\n\n".format(test_base, test_base))
-
+        "    pass\n\n")
     errors = []
     # check if a file already exists
     base_path = os.path.join(root_path, 'projects', project, 'tests')
     full_path = os.path.join(base_path, os.sep.join(parents))
     filepath = os.path.join(full_path, '{}.py'.format(tc_name))
-
-    if tc_name == test_base:
-        errors.append('base testcase will be generated automatically')
-    elif os.path.isfile(filepath):
+    if os.path.isfile(filepath):
         errors.append('a test with that name already exists')
     if not errors:
         # create the directory structure if it does not exist
@@ -192,33 +187,8 @@ def new_test_case(root_path, project, parents, tc_name):
         with open(filepath, 'w') as test_file:
             test_file.write(test_case_content)
         print('Test {} created for project {}'.format(tc_name, project))
-        new_base_test_case(root_path, project, parents, test_base)
     return errors
 
-def new_base_test_case(root_path, project, parents, test_base):
-
-    """Create a Test Base page."""
-    test_case_content = (
-        "\n"
-        "pages = []\n\n"
-        "def setup(data):\n"
-        "    pass\n\n"
-        "def teardown(data):\n"
-        "    pass\n\n")
-    # check if a file already exists
-    base_path = os.path.join(root_path, 'projects', project, 'tests')
-    full_path = os.path.join(base_path, os.sep.join(parents))
-    filepath = os.path.join(full_path, '{}.py'.format(test_base))
-    if not os.path.isfile(filepath):
-        # create the directory structure if it does not exist
-        if not os.path.isdir(full_path):
-            for parent in parents:
-                base_path = os.path.join(base_path, parent)
-                file_manager.create_directory(path=base_path, add_init=True)
-        
-        with open(filepath, 'w') as test_file:
-            test_file.write(test_case_content)
-        print('{} page created for project {}'.format(test_base, project))
 
 def _format_page_object_string(page_objects):
     """Format page object string to store in test case."""

--- a/golem/core/test_case.py
+++ b/golem/core/test_case.py
@@ -200,6 +200,8 @@ def new_base_test_case(root_path, project, parents, test_base):
     """Create a Test Base page."""
     test_case_content = (
         "\n\n"
+        "description = 'Gereral setup and teardown for all testcases'\n\n"
+        "pages = []\n\n"
         "def setup(data):\n"
         "    pass\n\n"
         "def teardown(data):\n"
@@ -277,6 +279,7 @@ def save_test_case(root_path, project, full_test_case_name, description,
 
     full_test_case_name is a relative dot path to the test
     """
+    print("save_test_case "+full_test_case_name)
     test_case_path = generate_test_case_path(root_path, project,
                                              full_test_case_name)
     formatted_description = _format_description(description)

--- a/golem/core/test_case.py
+++ b/golem/core/test_case.py
@@ -170,7 +170,7 @@ def new_test_case(root_path, project, parents, tc_name):
         "def test(data):\n"
         "    pass\n\n"
         "def teardown(data):\n"
-        "    {}.setup(data)\n\n".format(test_base, test_base))
+        "    {}.teardown(data)\n\n".format(test_base, test_base))
 
     errors = []
     # check if a file already exists

--- a/golem/core/utils.py
+++ b/golem/core/utils.py
@@ -17,9 +17,8 @@ from golem.core import file_manager
 
 
 def get_test_cases(workspace, project):
-    test_base = settings_manager.get_project_settings(workspace, project)['base_name']
     path = os.path.join(workspace, 'projects', project, 'tests')
-    test_cases = file_manager.generate_file_structure_dict(full_path=path, exclude_name=test_base+".py")
+    test_cases = file_manager.generate_file_structure_dict(path)
     return test_cases
 
 

--- a/golem/core/utils.py
+++ b/golem/core/utils.py
@@ -16,10 +16,13 @@ from golem.core import settings_manager
 from golem.core import file_manager
 
 
-def get_test_cases(workspace, project):
-    test_base = settings_manager.get_project_settings(workspace, project)['base_name']
+def get_test_cases(workspace, project, is_suite_view=False):
     path = os.path.join(workspace, 'projects', project, 'tests')
-    test_cases = file_manager.generate_file_structure_dict(full_path=path, exclude_name=test_base+".py")
+    if is_suite_view:
+        test_base = settings_manager.get_project_settings(workspace, project)['base_name']
+        test_cases = file_manager.generate_file_structure_dict(full_path=path, exclude_name=test_base+".py")
+    else:
+        test_cases = file_manager.generate_file_structure_dict(full_path=path)
     return test_cases
 
 

--- a/golem/core/utils.py
+++ b/golem/core/utils.py
@@ -17,8 +17,9 @@ from golem.core import file_manager
 
 
 def get_test_cases(workspace, project):
+    test_base = settings_manager.get_project_settings(workspace, project)['base_name']
     path = os.path.join(workspace, 'projects', project, 'tests')
-    test_cases = file_manager.generate_file_structure_dict(path)
+    test_cases = file_manager.generate_file_structure_dict(full_path=path, exclude_name=test_base+".py")
     return test_cases
 
 

--- a/golem/gui/__init__.py
+++ b/golem/gui/__init__.py
@@ -260,7 +260,8 @@ def page_code_view_no_sidebar(project, full_page_name):
 def suite_view(project, suite):
     if not user.has_permissions_to_project(g.user.id, project, root_path, 'gui'):
         return render_template('not_permission.html')
-    all_test_cases = utils.get_test_cases(root_path, project)
+
+    all_test_cases = utils.get_test_cases(root_path, project, is_suite_view=True)
     selected_tests = suite_module.get_suite_test_cases(root_path, project, suite)
     worker_amount = suite_module.get_suite_amount_of_workers(root_path, project, suite)
     browsers = suite_module.get_suite_browsers(root_path, project, suite)
@@ -268,6 +269,7 @@ def suite_view(project, suite):
     default_browser = test_execution.settings['default_browser']
     environments = suite_module.get_suite_environments(root_path, project, suite)
     environments = ', '.join(environments)
+
     return render_template('suite.html',
                            project=project,
                            all_test_cases=all_test_cases['sub_elements'],
@@ -285,7 +287,6 @@ def global_settings():
     if not user.has_permissions_to_project(g.user.id, project, root_path, 'gui'):
         return render_template('not_permission.html')
     global_settings = settings_manager.get_global_settings_as_string(root_path)
-    print(global_settings)
     return render_template('settings.html', project=None,
                            global_settings=global_settings, settings=None)
 

--- a/golem/gui/__init__.py
+++ b/golem/gui/__init__.py
@@ -260,7 +260,6 @@ def page_code_view_no_sidebar(project, full_page_name):
 def suite_view(project, suite):
     if not user.has_permissions_to_project(g.user.id, project, root_path, 'gui'):
         return render_template('not_permission.html')
-
     all_test_cases = utils.get_test_cases(root_path, project)
     selected_tests = suite_module.get_suite_test_cases(root_path, project, suite)
     worker_amount = suite_module.get_suite_amount_of_workers(root_path, project, suite)
@@ -269,7 +268,6 @@ def suite_view(project, suite):
     default_browser = test_execution.settings['default_browser']
     environments = suite_module.get_suite_environments(root_path, project, suite)
     environments = ', '.join(environments)
-    
     return render_template('suite.html',
                            project=project,
                            all_test_cases=all_test_cases['sub_elements'],
@@ -287,6 +285,7 @@ def global_settings():
     if not user.has_permissions_to_project(g.user.id, project, root_path, 'gui'):
         return render_template('not_permission.html')
     global_settings = settings_manager.get_global_settings_as_string(root_path)
+    print(global_settings)
     return render_template('settings.html', project=None,
                            global_settings=global_settings, settings=None)
 
@@ -789,6 +788,8 @@ def new_tree_element():
         full_path = full_path.split('.')
         element_name = full_path.pop()
         parents = full_path
+
+        test_base = ""
         # verify that the string only contains letters, numbers
         # dashes or underscores
         for c in element_name:
@@ -804,7 +805,8 @@ def new_tree_element():
                                                                 dir_type='tests')
                 else:
                     errors = test_case.new_test_case(root_path, project,
-                                                     parents, element_name)
+                                                     parents, element_name)  
+                    test_base = settings_manager.get_project_settings(root_path, project)['base_name']
                     # changelog.log_change(root_path, project, 'CREATE', 'test',
                     #                      full_path, g.user.username)
             elif elem_type == 'page':
@@ -826,8 +828,10 @@ def new_tree_element():
             'name': element_name,
             'full_path': dot_path,
             'type': elem_type,
-            'is_directory': is_dir
+            'is_directory': is_dir,
+            'test_base': test_base
         }
+        print("path is: " + json.dumps(element))
         return json.dumps({'errors': errors, 'project_name': project,
                            'element': element})
 

--- a/golem/gui/__init__.py
+++ b/golem/gui/__init__.py
@@ -260,6 +260,7 @@ def page_code_view_no_sidebar(project, full_page_name):
 def suite_view(project, suite):
     if not user.has_permissions_to_project(g.user.id, project, root_path, 'gui'):
         return render_template('not_permission.html')
+
     all_test_cases = utils.get_test_cases(root_path, project)
     selected_tests = suite_module.get_suite_test_cases(root_path, project, suite)
     worker_amount = suite_module.get_suite_amount_of_workers(root_path, project, suite)
@@ -268,6 +269,7 @@ def suite_view(project, suite):
     default_browser = test_execution.settings['default_browser']
     environments = suite_module.get_suite_environments(root_path, project, suite)
     environments = ', '.join(environments)
+    
     return render_template('suite.html',
                            project=project,
                            all_test_cases=all_test_cases['sub_elements'],
@@ -285,7 +287,6 @@ def global_settings():
     if not user.has_permissions_to_project(g.user.id, project, root_path, 'gui'):
         return render_template('not_permission.html')
     global_settings = settings_manager.get_global_settings_as_string(root_path)
-    print(global_settings)
     return render_template('settings.html', project=None,
                            global_settings=global_settings, settings=None)
 
@@ -788,8 +789,6 @@ def new_tree_element():
         full_path = full_path.split('.')
         element_name = full_path.pop()
         parents = full_path
-
-        test_base = ""
         # verify that the string only contains letters, numbers
         # dashes or underscores
         for c in element_name:
@@ -805,8 +804,7 @@ def new_tree_element():
                                                                 dir_type='tests')
                 else:
                     errors = test_case.new_test_case(root_path, project,
-                                                     parents, element_name)  
-                    test_base = settings_manager.get_project_settings(root_path, project)['base_name']
+                                                     parents, element_name)
                     # changelog.log_change(root_path, project, 'CREATE', 'test',
                     #                      full_path, g.user.username)
             elif elem_type == 'page':
@@ -828,10 +826,8 @@ def new_tree_element():
             'name': element_name,
             'full_path': dot_path,
             'type': elem_type,
-            'is_directory': is_dir,
-            'test_base': test_base
+            'is_directory': is_dir
         }
-        print("path is: " + json.dumps(element))
         return json.dumps({'errors': errors, 'project_name': project,
                            'element': element})
 

--- a/golem/gui/static/js/project.js
+++ b/golem/gui/static/js/project.js
@@ -211,7 +211,7 @@ var Project = new function(){
                                     url: elementUrl,
                                     dotPath: base_path, 
                                     type: data.element.type});
-                                parentUl.children().last().before(uiElement);
+                                parentUl.children().first().before(uiElement);
                             }
                         }
                         

--- a/golem/gui/static/js/project.js
+++ b/golem/gui/static/js/project.js
@@ -192,7 +192,6 @@ var Project = new function(){
                         parentUl.children().last().before(branch);
                     }
                     else{
-
                         var elementUrl = "/project/"+data.project_name+"/"+data.element.type+"/"+data.element.full_path+"/";
                         var uiElement = Project.generateNewElement({
                             name: data.element.name,
@@ -200,21 +199,6 @@ var Project = new function(){
                             dotPath: data.element.full_path, 
                             type: data.element.type});
                         parentUl.children().last().before(uiElement);
-
-                        if(data.element.test_base != ""){
-                            var base_path = data.element.full_path.replace(data.element.name, data.element.test_base)
-                            var isBaseExists = $("li[fullpath='"+base_path+"']")
-                            if(isBaseExists.length == "0"){
-                                elementUrl = "/project/"+data.project_name+"/"+data.element.type+"/"+base_path+"/";
-                                var uiElement = Project.generateNewElement({
-                                    name: data.element.test_base,
-                                    url: elementUrl,
-                                    dotPath: base_path, 
-                                    type: data.element.type});
-                                parentUl.children().last().before(uiElement);
-                            }
-                        }
-                        
                     }
                     // reset the form, hide the form and display the add new link
                     input.val("");

--- a/golem/gui/static/js/project.js
+++ b/golem/gui/static/js/project.js
@@ -192,6 +192,7 @@ var Project = new function(){
                         parentUl.children().last().before(branch);
                     }
                     else{
+
                         var elementUrl = "/project/"+data.project_name+"/"+data.element.type+"/"+data.element.full_path+"/";
                         var uiElement = Project.generateNewElement({
                             name: data.element.name,
@@ -199,6 +200,21 @@ var Project = new function(){
                             dotPath: data.element.full_path, 
                             type: data.element.type});
                         parentUl.children().last().before(uiElement);
+
+                        if(data.element.test_base != ""){
+                            var base_path = data.element.full_path.replace(data.element.name, data.element.test_base)
+                            var isBaseExists = $("li[fullpath='"+base_path+"']")
+                            if(isBaseExists.length == "0"){
+                                elementUrl = "/project/"+data.project_name+"/"+data.element.type+"/"+base_path+"/";
+                                var uiElement = Project.generateNewElement({
+                                    name: data.element.test_base,
+                                    url: elementUrl,
+                                    dotPath: base_path, 
+                                    type: data.element.type});
+                                parentUl.children().last().before(uiElement);
+                            }
+                        }
+                        
                     }
                     // reset the form, hide the form and display the add new link
                     input.val("");

--- a/golem/test_runner/start_execution.py
+++ b/golem/test_runner/start_execution.py
@@ -95,8 +95,11 @@ def _define_execution_list(workspace, project, execution):
       - driver
     """
     execution_list = []
+    test_base = settings_manager.get_project_settings(workspace, project)['base_name']
     envs_data = environment_manager.get_environment_data(workspace, project)
     for test in execution['tests']:
+        if test.split(".")[-1] == test_base:
+            continue
         data_sets = test_data.get_test_data(workspace, project, test)
         for data_set in data_sets:
             for env in execution['environments']:

--- a/golem/test_runner/start_execution.py
+++ b/golem/test_runner/start_execution.py
@@ -95,11 +95,8 @@ def _define_execution_list(workspace, project, execution):
       - driver
     """
     execution_list = []
-    test_base = settings_manager.get_project_settings(workspace, project)['base_name']
     envs_data = environment_manager.get_environment_data(workspace, project)
     for test in execution['tests']:
-        if test.split(".")[-1] == test_base:
-            continue
         data_sets = test_data.get_test_data(workspace, project, test)
         for data_set in data_sets:
             for env in execution['environments']:

--- a/golem/test_runner/test_runner.py
+++ b/golem/test_runner/test_runner.py
@@ -108,6 +108,12 @@ def run_test(workspace, project, test_name, test_data, browser,
             for page in test_module.pages:
                 test_module = import_page_into_test_module(project, test_module,
                                                            page)
+        if hasattr(base_module, 'pages'):
+            for page in base_module.pages:
+                test_module = import_page_into_test_module(project, test_module,
+                                                           page)
+                base_module = import_page_into_test_module(project, base_module,
+                                                           page)
 
         # import logger into the test module
         setattr(test_module, 'logger', execution.logger)

--- a/golem/test_runner/test_runner.py
+++ b/golem/test_runner/test_runner.py
@@ -60,8 +60,8 @@ def run_test(workspace, project, test_name, test_data, browser,
                                          settings['log_all_events'])
     execution.logger = logger
     # Print execution info to console
-    logger.info('Test execution started a: {}'.format(test_name))
-    logger.info('Browser a: {}'.format(browser['name']))
+    logger.info('Test execution started: {}'.format(test_name))
+    logger.info('Browser: {}'.format(browser['name']))
     if 'env' in test_data:
         if 'name' in test_data['env']:
             logger.info('Environment: {}'.format(test_data['env']['name']))
@@ -105,11 +105,9 @@ def run_test(workspace, project, test_name, test_data, browser,
 
         # import each page into the test_module
         if hasattr(test_module, 'pages'):
-            logger.info('Importing pages')
             for page in test_module.pages:
                 test_module = import_page_into_test_module(project, test_module,
                                                            page)
-                logger.info('Testmodule is: {}'.format(test_module))
 
         # import logger into the test module
         setattr(test_module, 'logger', execution.logger)

--- a/golem/test_runner/test_runner.py
+++ b/golem/test_runner/test_runner.py
@@ -5,7 +5,7 @@ import importlib
 import time
 import traceback
 
-from golem.core import report, utils, settings_manager
+from golem.core import report, utils
 from golem.test_runner.test_runner_utils import import_page_into_test_module
 
 
@@ -60,8 +60,8 @@ def run_test(workspace, project, test_name, test_data, browser,
                                          settings['log_all_events'])
     execution.logger = logger
     # Print execution info to console
-    logger.info('Test execution started a: {}'.format(test_name))
-    logger.info('Browser a: {}'.format(browser['name']))
+    logger.info('Test execution started: {}'.format(test_name))
+    logger.info('Browser: {}'.format(browser['name']))
     if 'env' in test_data:
         if 'name' in test_data['env']:
             logger.info('Environment: {}'.format(test_data['env']['name']))
@@ -90,27 +90,18 @@ def run_test(workspace, project, test_name, test_data, browser,
     sys.path.append(os.path.join(workspace, 'projects', project))
 
     test_module = None
-    test_base = settings_manager.get_project_settings(workspace, project)['base_name']
+
     try:
         if '/' in test_name:
             test_name = test_name.replace('/', '.')
-            
-        test_base_fullpath = test_name.replace(test_name.split(".")[-1], test_base)
         test_module = importlib.import_module(
             'projects.{0}.tests.{1}'.format(project, test_name))
 
-        base_module = importlib.import_module(
-            'projects.{0}.tests.{1}'.format(project, test_base_fullpath))
-        setattr(test_module, test_base, base_module)
-
         # import each page into the test_module
         if hasattr(test_module, 'pages'):
-            logger.info('Importing pages')
             for page in test_module.pages:
                 test_module = import_page_into_test_module(project, test_module,
                                                            page)
-                logger.info('Testmodule is: {}'.format(test_module))
-
         # import logger into the test module
         setattr(test_module, 'logger', execution.logger)
         # import actions into the test module

--- a/golem/test_runner/test_runner.py
+++ b/golem/test_runner/test_runner.py
@@ -5,7 +5,7 @@ import importlib
 import time
 import traceback
 
-from golem.core import report, utils
+from golem.core import report, utils, settings_manager
 from golem.test_runner.test_runner_utils import import_page_into_test_module
 
 
@@ -60,8 +60,8 @@ def run_test(workspace, project, test_name, test_data, browser,
                                          settings['log_all_events'])
     execution.logger = logger
     # Print execution info to console
-    logger.info('Test execution started: {}'.format(test_name))
-    logger.info('Browser: {}'.format(browser['name']))
+    logger.info('Test execution started a: {}'.format(test_name))
+    logger.info('Browser a: {}'.format(browser['name']))
     if 'env' in test_data:
         if 'name' in test_data['env']:
             logger.info('Environment: {}'.format(test_data['env']['name']))
@@ -90,18 +90,27 @@ def run_test(workspace, project, test_name, test_data, browser,
     sys.path.append(os.path.join(workspace, 'projects', project))
 
     test_module = None
-
+    test_base = settings_manager.get_project_settings(workspace, project)['base_name']
     try:
         if '/' in test_name:
             test_name = test_name.replace('/', '.')
+            
+        test_base_fullpath = test_name.replace(test_name.split(".")[-1], test_base)
         test_module = importlib.import_module(
             'projects.{0}.tests.{1}'.format(project, test_name))
 
+        base_module = importlib.import_module(
+            'projects.{0}.tests.{1}'.format(project, test_base_fullpath))
+        setattr(test_module, test_base, base_module)
+
         # import each page into the test_module
         if hasattr(test_module, 'pages'):
+            logger.info('Importing pages')
             for page in test_module.pages:
                 test_module = import_page_into_test_module(project, test_module,
                                                            page)
+                logger.info('Testmodule is: {}'.format(test_module))
+
         # import logger into the test module
         setattr(test_module, 'logger', execution.logger)
         # import actions into the test module

--- a/golem/test_runner/test_runner_utils.py
+++ b/golem/test_runner/test_runner_utils.py
@@ -22,5 +22,6 @@ def import_page_into_test_module(project, parent_module, page_path, page_path_li
     else:
         imported_module = importlib.import_module('projects.{}.pages.{}'
                                                   .format(project, page_path))
+        print("setattr: " + page_path_list[0])
         setattr(parent_module, page_path_list[0], imported_module)
     return parent_module

--- a/golem/test_runner/test_runner_utils.py
+++ b/golem/test_runner/test_runner_utils.py
@@ -22,6 +22,5 @@ def import_page_into_test_module(project, parent_module, page_path, page_path_li
     else:
         imported_module = importlib.import_module('projects.{}.pages.{}'
                                                   .format(project, page_path))
-        print("setattr: " + page_path_list[0])
         setattr(parent_module, page_path_list[0], imported_module)
     return parent_module


### PR DESCRIPTION
Right now if we have to implement so many test cases that use the same `setup` and `teardown`, we have to copy/paste it over and over again. 
With this change, we will have a test base file that contains those shared steps. All tests in a folder will use the same setup and teardown, but user till have an options to use different setup for specific test by just remove the testbase caller in their testcase.
This is how basic testcase and testbase look like:
<img width="383" alt="screen shot 2018-09-07 at 10 16 01 am" src="https://user-images.githubusercontent.com/30398990/45196975-19540300-b289-11e8-8a42-45c44c9eaee5.png">
<img width="333" alt="screen shot 2018-09-07 at 10 29 38 am" src="https://user-images.githubusercontent.com/30398990/45196981-1fe27a80-b289-11e8-960d-db514aaa7408.png">
