### PR TITLE
Output junit xml

### DIFF
--- a/golem/cli/argument_parser.py
+++ b/golem/cli/argument_parser.py
@@ -18,6 +18,8 @@ def get_parser():
                             nargs='*', default=[], type=str)
     parser_run.add_argument('-i', '--interactive', action='store_true',
                             default=False)
+    parser_run.add_argument('-j', '--junit', action='store_true',
+                            default=False)
     parser_run.add_argument('--timestamp', action='store', nargs='?', type=str)
     parser_run.add_argument('-h', '--help', action='store_true')
 

--- a/golem/cli/commands.py
+++ b/golem/cli/commands.py
@@ -19,7 +19,7 @@ def command_dispatcher(args):
         run_command(args.project, args.test_query,
                     args.browsers, args.threads,
                     args.environments, args.interactive,
-                    args.timestamp)
+                    args.junit, args.timestamp)
     elif args.command == 'gui':
         gui_command(args.port)
     elif args.command == 'createproject':
@@ -53,7 +53,7 @@ def display_help(help, command):
 
 
 def run_command(project='', test_query='', browsers=None, processes=1,
-                environments=None, interactive=False, timestamp=None):
+                environments=None, interactive=False, junit=False, timestamp=None):
     execution_runner = ExecutionRunner(browsers, processes, environments,
                                        interactive, timestamp)
     if project:
@@ -72,7 +72,7 @@ def run_command(project='', test_query='', browsers=None, processes=1,
                     execution_runner.run_suite(test_query)
                 elif test_case.test_case_exists(test_execution.root_path,
                                                 project, test_query):
-                    execution_runner.run_test(test_query)
+                    execution_runner.run_test(test_query, junit)
                 else:
                     if test_query == '.':
                         test_query = ''

--- a/golem/cli/commands.py
+++ b/golem/cli/commands.py
@@ -66,13 +66,17 @@ def run_command(project='', test_query='', browsers=None, processes=1,
             # add --interactive value to settings to make
             # it available from inside a test
             test_execution.settings['interactive'] = interactive
+
+            # add --junit value to settings to output junit.xml for ci tools.
+            test_execution.settings['junit'] = junit
+
             if test_query:
                 if suite_module.suite_exists(test_execution.root_path,
                                              project, test_query):
                     execution_runner.run_suite(test_query)
                 elif test_case.test_case_exists(test_execution.root_path,
                                                 project, test_query):
-                    execution_runner.run_test(test_query, junit)
+                    execution_runner.run_test(test_query)
                 else:
                     if test_query == '.':
                         test_query = ''

--- a/golem/cli/messages.py
+++ b/golem/cli/messages.py
@@ -2,7 +2,7 @@
 USAGE_MSG = """
 Usage: golem
 
-  golem run <project> <test|suite|directory> [-b -t -e -i]
+  golem run <project> <test|suite|directory> [-b -t -e -i -j]
   golem gui [-p]
   golem createproject <project>
   golem createtest <project> <test>
@@ -29,6 +29,7 @@ Usage: golem run
     -t, --threads       amount of threads, default is 1
     -e, --environments  a list of environments
     -i, --interactive   run in interactive mode
+    -j, --junit         output junit.xml file
 
 Usage: golem gui
   
@@ -42,7 +43,7 @@ Type: golem -h <command> for more help
 
 RUN_USAGE_MSG = """
 Usage: golem run <project> <test|suite|directory> [-b|--browsers]
-                 [-t|--threads] [-e|--environments] [-i|--interactive]
+                 [-t|--threads] [-e|--environments] [-i|--interactive] [-j|--junit]
 
   Run tests, suites or directories
   
@@ -77,6 +78,8 @@ Usage: golem run <project> <test|suite|directory> [-b|--browsers]
     -t, --threads       amount of threads, default is 1
     -e, --environments  a list of environments
     -i, --interactive   run in interactive mode
+    -j, --junit         output junit.xml file
+
 """
 
 GUI_USAGE_MSG = """

--- a/golem/test_runner/execution_runner.py
+++ b/golem/test_runner/execution_runner.py
@@ -326,3 +326,7 @@ class ExecutionRunner:
         # generate execution_result.json
         elapsed_time = round(time.time() - start_time, 2)
         report_parser.generate_execution_report(self.execution.reportdir, elapsed_time)
+
+        # generate execution_result.xml if junit enabled
+        if test_execution.settings['junit']:
+            report_parser.generate_junit_execution_report(self.suite_name, self.execution.reportdir, elapsed_time)


### PR DESCRIPTION
When running a test suite with -j or --junit, an execution_report.xml is output to the execution reports, along with the existing execution_report.json

It currently doesn't have the individual test steps in the failure or error message section of the xml, but it does come put in the build log in the event of an error.

This is what the output looks like when using Bamboo to run the tests.
![image](https://user-images.githubusercontent.com/10735724/49785458-98127d80-fd5b-11e8-8807-18304fa4e2aa.png)
