### PR TITLE
Treat 'else' as part of a single block

### DIFF
--- a/golem/core/test_parser.py
+++ b/golem/core/test_parser.py
@@ -131,7 +131,7 @@ def _split_code_into_blocks(code):
     for line in code_lines:
         if block is None:
             block = line + '\n'
-        elif len(line) - len(line.lstrip()) > 0:
+        elif len(line) - len(line.lstrip()) > 0 or re.match(r'^else:', line.lstrip()):
             block += line + '\n'
         elif len(line) - len(line.lstrip()) == 0:
             blocks.append(block)


### PR DESCRIPTION
Code that was using an if / else was causing a 500 server error because the statement

```
if True:
    pass
else:
    pass
```

would be appraised as two separate blocks and then ast was unable to process the block

```
else:
    pass
```

This change treats any line that starts with `else:` as still part of the same block.