### PR TITLE
Fix for run test in custom directory configured with --golem-dir from GUI

### DIFF
--- a/golem/gui/gui_utils.py
+++ b/golem/gui/gui_utils.py
@@ -32,7 +32,15 @@ def run_test(project, test_name, browsers=None, environments=None, processes=1):
     """Run a test case. This is used when running tests from the GUI"""
     script_name = sys.argv[0]
     timestamp = utils.get_timestamp()
-    param_list = [script_name, 'run', project, test_name, '--timestamp', timestamp]
+    param_list = [
+        script_name,
+        '--golem-dir',
+        session.testdir,
+        'run',
+        project,
+        test_name,
+        '--timestamp', 
+        timestamp]
 
     if browsers:
         param_list.append('--browsers')
@@ -45,7 +53,7 @@ def run_test(project, test_name, browsers=None, environments=None, processes=1):
     if processes:
         param_list.append('--processes')
         param_list.append(str(processes))
-
+    
     subprocess.Popen(param_list)
     return timestamp
 

--- a/golem/gui/gui_utils.py
+++ b/golem/gui/gui_utils.py
@@ -39,7 +39,7 @@ def run_test(project, test_name, browsers=None, environments=None, processes=1):
         'run',
         project,
         test_name,
-        '--timestamp', 
+        '--timestamp',
         timestamp]
 
     if browsers:
@@ -53,7 +53,7 @@ def run_test(project, test_name, browsers=None, environments=None, processes=1):
     if processes:
         param_list.append('--processes')
         param_list.append(str(processes))
-    
+
     subprocess.Popen(param_list)
     return timestamp
 


### PR DESCRIPTION
## Description

if you have this folder structure:
```
custom_project/
-- golem_project/
-- Pipfile
```

And inside `Pipfile`:
```toml
[scripts]
gui="golem --golem-dir ./golem_project gui"
```

When you run `pipenv run gui` and you run some test from the gui then an exception is raised:
```
127.0.0.1 - - [20/Mar/2020 18:09:06] "POST /api/test/run HTTP/1.1" 200 -
Error: ..../custom_project is not an valid Golem test directory; .golem file not found
```