### PR TITLE
Check if current process is golem or some other WSGI server

### DIFF
--- a/golem/gui/gui_utils.py
+++ b/golem/gui/gui_utils.py
@@ -28,6 +28,9 @@ def is_safe_url(target):
 def run_test(project, test_name, browsers=None, environments=None, processes=1):
     """Run a test case. This is used when running tests from the GUI"""
     script_name = sys.argv[0]
+    if script_name[-5:] != 'golem':
+        which_golem = subprocess.run(['which', 'golem'], stdout=subprocess.PIPE)
+        script_name = which_golem.stdout.decode('utf-8').strip()
     timestamp = utils.get_timestamp()
     param_list = [
         script_name,
@@ -58,6 +61,9 @@ def run_test(project, test_name, browsers=None, environments=None, processes=1):
 def run_suite(project, suite_name):
     """Run a suite. This is used when running suites from the GUI"""
     script_name = sys.argv[0]
+    if script_name[-5:] != 'golem':
+        which_golem = subprocess.run(['which', 'golem'], stdout=subprocess.PIPE)
+        script_name = which_golem.stdout.decode('utf-8').strip()
     timestamp = utils.get_timestamp()
     param_list = [
         script_name,


### PR DESCRIPTION
When running golem inside a WSGI server (e.g. `waitress-serve --call "golem.gui:create_app"`) tests and suites fail to start because it tries to call the current process with the required arguments. But the current process is not golem, it's wiatress (or whichever server is running).

I added a check to see if the current process is golem. If it's not then it runs the command `which golem` to find the golem path.

I'm not sure if that's the best way to solve the issue, if it's not feel free to reject this pull request and suggest a better way.