### PR TITLE
Download ChromeDriver in 'golem-admin createdirectory' command

### DIFF
--- a/golem/cli/commands.py
+++ b/golem/cli/commands.py
@@ -1,7 +1,8 @@
 import os
 import sys
 
-import webdriver_manager
+from selenium import webdriver
+from webdriver_manager.chrome import ChromeDriverManager
 
 import golem
 from golem.core import errors
@@ -229,13 +230,12 @@ def createdirectory_command(dir_name, no_confirm=False, download_drivers=True):
     print('  password: admin')
 
     if download_drivers:
-        drivers_folder = os.path.join(abspath, 'drivers')
         update = True
         if not no_confirm:
             msg = 'Would you like to download ChromeDriver now? [Y/n]'
             update = utils.prompt_yes_no(msg, True)
         if update:
-            webdriver_manager.update('chrome', drivers_folder)
+            webdriver.Chrome(ChromeDriverManager(path=abspath).install())
 
 
 def display_version():


### PR DESCRIPTION
Output after run the golem-admin createdirectory testdir
New golem test directory created at D:\Golem_Project_9.2\testdir
Use these credentials to access the GUI module:
  user:     admin
  password: admin
Would you like to download ChromeDriver now? [Y/n]Y


[WDM] - ====== WebDriver manager ======
[WDM] - Current google-chrome version is 89.0.4389
[WDM] - Get LATEST driver version for 89.0.4389
[WDM] - There is no [win32] chromedriver for browser 89.0.4389 in cache
[WDM] - Get LATEST driver version for 89.0.4389
[WDM] - Trying to download new driver from https://chromedriver.storage.googleapis.com/89.0.4389.23/chromedriver_win32.zip
[WDM] - Driver has been saved in cache [D:\Golem_Project_9.2\testdir\drivers\chromedriver\win32\89.0.4389.23]

DevTools listening on ws://127.0.0.1:59139/devtools/browser/6f84b1f7-4af8-48a8-8fc6-8f20a5901297