### PR TITLE
use 'full_name' as a value of JUnit report's 'name' field for a testcase

### DIFF
--- a/golem/report/junit_report.py
+++ b/golem/report/junit_report.py
@@ -39,10 +39,8 @@ def generate_junit_report(project_name, suite_name, timestamp, report_folder=Non
     testsuite = ET.SubElement(testsuites, 'testsuite', testsuites_attrs)
 
     for test in data['tests']:
-        # If the sets have names use them, otherwise use the generated name.
-        set_name = test['set_name'] if test['set_name'] is not "" else test['test_set']
         test_attrs = {
-            'name': set_name,
+            'name': test['full_name'],
             'classname': test['full_name'],
             'time': str(test['test_elapsed_time'])
         }


### PR DESCRIPTION
Hello!

As reported in https://github.com/golemhq/golem/issues/210 the JUnit report of Golem test run gives every test a new name each run and as such breaks history/stats in CI (Azure DevOps in my case).

Definition of JUnit XML report schema states that test name is the only required attribute of a "testcase": https://github.com/junit-team/junit5/blob/main/platform-tests/src/test/resources/jenkins-junit.xsd 
```
<xs:attribute name="name" type="xs:string" use="required"/>
<xs:attribute name="assertions" type="xs:string" use="optional"/>
<xs:attribute name="time" type="xs:string" use="optional"/>
<xs:attribute name="classname" type="xs:string" use="optional"/>
<xs:attribute name="status" type="xs:string" use="optional"/>
```

In py.test, unittest or any other test runner the name of the test method would be the name of the method, but in Golem test method is always named "test". As such the name of the test should be derives from a file name, that is `test['full_name']`.

Fast test run completed:
`==================================================== 420 passed, 101 skipped, 3 warnings in 10.38s ====================================================
(venv)`