### PR TITLE
if we deal with a set - append set's name to test name

### DIFF
--- a/golem/report/junit_report.py
+++ b/golem/report/junit_report.py
@@ -39,8 +39,16 @@ def generate_junit_report(project_name, suite_name, timestamp, report_folder=Non
     testsuite = ET.SubElement(testsuites, 'testsuite', testsuites_attrs)
 
     for test in data['tests']:
+        test_name = test['full_name']
+
+        # if there are sets - append set name
+        # if the sets' name is empty - use the generated name
+        if test['data']:
+            set_name = test['set_name'] if test['set_name'] is not "" else test['test_set']
+            test_name += '_' + set_name
+
         test_attrs = {
-            'name': test['full_name'],
+            'name': test_name,
             'classname': test['full_name'],
             'time': str(test['test_elapsed_time'])
         }


### PR DESCRIPTION
@luciano-renzi in addition to PR #211 

I had some thought and came up with this better solution.

Imagine a test_one.py and a set:
```
"set_name","dummy"
"one","qw"
"two","we"
"three","er"
"","ty"
```

with my #211 these will now be reported as "test_one" four times in JUnit report.
with current code it will be
- testOne_one
- testOne_two
- testOne_three
- testOne_set_02a9be

which is better than random names from sets :)
it's up to user to name sets correctly which will keep tests' names consistent across runs and history/stats